### PR TITLE
Fix environment(env) option

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function Weird(options) {
 	var env = options.env;
 	if (env) {
 		if (!Array.isArray(options.env)) env = env.split(/[,\s]+/);
-		globalEnvs.concat(env);
+		globalEnvs = globalEnvs.concat(env);
 	}
 	globalEnvs.forEach(function(group) {
 		if (!globals[group]) return;


### PR DESCRIPTION
Array::concat creates a new Array, and does not modify the `globalEnvs` array.

Test code:

``` js
var fs, weird;

weird = require('./index.js');

fs = require('fs');

fs.writeFileSync("./index.weird.js", weird(fs.readFileSync("./index.js", "utf8"), {
  env: "node"
}).code);
```
